### PR TITLE
Use AC_HEADER_STDBOOL for better compatibility.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -165,7 +165,7 @@ AC_CHECK_HEADERS([stdlib.h string.h])
 
 
 # Checks for typedefs, structures, and compiler characteristics.
-AC_CHECK_HEADER_STDBOOL
+AC_HEADER_STDBOOL
 AC_C_RESTRICT
 
 # Checks for library functions.

--- a/include/234compositor.h
+++ b/include/234compositor.h
@@ -29,7 +29,9 @@
 #include <math.h>    // ceil, M_LOG2E
 #include <stdio.h>   // printf, fprintf, sprintf, fwrite, FILE
 #include <stdlib.h>  // atoi, free 
+#ifndef HAVE_STDBOOL_H
 #include <stdbool.h> // true, false
+#endif
 
 // C99 Compiler
 #if (__STDC_VERSION__ >= 199901L)


### PR DESCRIPTION
AC_CHECK_HEADER_STDBOOL has been replaced AC_HEADER_STDBOOL for better compatibility.
